### PR TITLE
Vi: insert mode escape seq fallback to command mode

### DIFF
--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -381,9 +381,18 @@ impl InputState {
         single_esc_abort: bool,
     ) -> Result<Cmd> {
         match self.mode {
-            EditMode::Emacs => self.emacs(rdr, wrt, single_esc_abort),
-            EditMode::Vi if self.input_mode != InputMode::Command => self.vi_insert(rdr, wrt),
-            EditMode::Vi => self.vi_command(rdr, wrt),
+            EditMode::Emacs => {
+                let key = rdr.next_key(single_esc_abort)?;
+                self.emacs(rdr, wrt, key)
+            }
+            EditMode::Vi if self.input_mode != InputMode::Command => {
+                let key = rdr.next_key(false)?;
+                self.vi_insert(rdr, wrt, key)
+            }
+            EditMode::Vi => {
+                let key = rdr.next_key(false)?;
+                self.vi_command(rdr, wrt, key)
+            }
         }
     }
 
@@ -432,9 +441,8 @@ impl InputState {
         &mut self,
         rdr: &mut R,
         wrt: &mut dyn Refresher,
-        single_esc_abort: bool,
+        mut key: KeyPress,
     ) -> Result<Cmd> {
-        let mut key = rdr.next_key(single_esc_abort)?;
         if let KeyPress::Meta(digit @ '-') = key {
             key = self.emacs_digit_argument(rdr, wrt, digit)?;
         } else if let KeyPress::Meta(digit @ '0'..='9') = key {
@@ -579,8 +587,12 @@ impl InputState {
         }
     }
 
-    fn vi_command<R: RawReader>(&mut self, rdr: &mut R, wrt: &mut dyn Refresher) -> Result<Cmd> {
-        let mut key = rdr.next_key(false)?;
+    fn vi_command<R: RawReader>(
+        &mut self,
+        rdr: &mut R,
+        wrt: &mut dyn Refresher,
+        mut key: KeyPress,
+    ) -> Result<Cmd> {
         if let KeyPress::Char(digit @ '1'..='9') = key {
             key = self.vi_arg_digit(rdr, wrt, digit)?;
         }
@@ -744,8 +756,12 @@ impl InputState {
         Ok(cmd)
     }
 
-    fn vi_insert<R: RawReader>(&mut self, rdr: &mut R, wrt: &mut dyn Refresher) -> Result<Cmd> {
-        let key = rdr.next_key(false)?;
+    fn vi_insert<R: RawReader>(
+        &mut self,
+        rdr: &mut R,
+        wrt: &mut dyn Refresher,
+        key: KeyPress,
+    ) -> Result<Cmd> {
         {
             let bindings = self.custom_bindings.read().unwrap();
             if let Some(cmd) = bindings.get(&key) {
@@ -775,9 +791,8 @@ impl InputState {
                 self.input_mode = InputMode::Command;
                 wrt.done_inserting();
 
-                // TODO: Do k as command key
-                Cmd::Move(Movement::BeginningOfLine)
-            },
+                self.vi_command(rdr, wrt, KeyPress::Char(k))?
+            }
             KeyPress::Esc => {
                 // vi-movement-mode/vi-command-mode
                 self.input_mode = InputMode::Command;


### PR DESCRIPTION
We don't expect Meta-X in Vi insert mode only ANSI escape sequence.
So Meta-X means Esc (exit insert mode) and do command associated to X.